### PR TITLE
DVO-4278 mount_points input type changed to list of maps

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -102,15 +102,12 @@ variable "log_options" {
 }
 
 variable "mount_points" {
-  type        = list(string)
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`"
-  default     = []
-  #default     = [
-  #  {
-  #    containerPath  = "/tmp"
-  #    sourceVolume = "test-volume"
-  #  }
-  #]
+  type = list(object({
+    containerPath = string
+    sourceVolume  = string
+  }))
+  default = []
 }
 
 variable "dns_servers" {


### PR DESCRIPTION
In order to be able to create a mount point in the task definition for a container, I need to change the input type from a list of string to a list of maps like it is currently in the original repository