### PR TITLE
[SRE-1276] Move healthcheck to be an object.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,10 +31,17 @@ variable "port_mappings" {
   ]
 }
 
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html
 variable "healthcheck" {
-  type        = map(string)
-  description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
-  default     = {}
+  type = object({
+    command     = list(string)
+    retries     = number
+    timeout     = number
+    interval    = number
+    startPeriod = number
+  })
+  description = "A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
+  default     = null
 }
 
 variable "container_cpu" {


### PR DESCRIPTION
healthcheck.command should accept list of strings

https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/33