### PR TITLE
[SRE-877] Support for placement constraints

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `` | no |
 | volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume). | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |
+| placement_constraints | Adds contraints to the container to limit where it can be scheduled | `<list>` | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ locals {
     stopTimeout            = "stop_timeout_sentinel_value"
     portMappings           = var.port_mappings
     healthCheck            = var.healthcheck
+    placementConstraints   = var.placement_constraints
     logConfiguration = {
       logDriver = var.log_driver
       options   = var.log_options

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,8 @@ variable "stop_timeout" {
   default     = 30
 }
 
+variable "placement_constraints" {
+  type        = list(map(string))
+  description = "Adds contraints to the container to limit where it can be scheduled"
+  default     = []
+}


### PR DESCRIPTION
This is required to be able to spread containers amongst the available instances.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html

```yaml
"placementConstraints": [
    {
        "type": "distinctInstance"
    }
]
```