### PR TITLE
DOS-26 - add support for docker_labels

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,9 @@ locals {
       logDriver = var.log_driver
       options   = var.log_options
     }
-    environment = "environment_sentinel_value"
-    secrets     = "secrets_sentinel_value"
+    environment  = "environment_sentinel_value"
+    secrets      = "secrets_sentinel_value"
+    dockerLabels = "docker_labels_sentinel_value"
   }
 
   environment = var.environment

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,7 +62,7 @@ locals {
     local.encoded_docker_labels,
   )
 
-  json_map = "${local.json_with_docker_labels}"
+  json_map = local.json_with_docker_labels
 }
 
 output "json" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ locals {
     "/\"(-?[0-9]+\\.?[0-9]*)\"/",
     "$1",
   )
-  encoded_docker_labels         = "${jsonencode(var.docker_labels)}"
+  encoded_docker_labels         = jsonencode(var.docker_labels)
 
   json_with_environment = replace(
     local.encoded_container_definition,

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ locals {
   encoded_memory                = var.container_memory > 0 ? var.container_memory : "null"
   encoded_memory_reservation    = var.container_memory_reservation > 0 ? var.container_memory_reservation : "null"
   encoded_stop_timeout          = var.stop_timeout > 0 ? var.stop_timeout : "null"
-  encoded_container_definition = replace(
+  encoded_container_definition  = replace(
     replace(
       replace(
         jsonencode(local.container_definition),
@@ -24,6 +24,7 @@ locals {
     "/\"(-?[0-9]+\\.?[0-9]*)\"/",
     "$1",
   )
+  encoded_docker_labels         = "${jsonencode(var.docker_labels)}"
 
   json_with_environment = replace(
     local.encoded_container_definition,
@@ -55,8 +56,13 @@ locals {
     "/\"stop_timeout_sentinel_value\"/",
     local.encoded_stop_timeout,
   )
+  json_with_docker_labels = replace(
+    local.json_with_stop_timeout,
+    "/\"docker_labels_sentinel_value\"/", 
+    local.encoded_docker_labels,
+  )
 
-  json_map = local.json_with_stop_timeout
+  json_map = "${local.json_with_docker_labels}"
 }
 
 output "json" {

--- a/variables.tf
+++ b/variables.tf
@@ -159,7 +159,7 @@ variable "container_depends_on" {
 }
 
 variable "docker_labels" {
-  type        = "map"
+  type        = map(string)
   description = "The configuration options to send to the `docker_labels`"
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,12 @@ variable "container_depends_on" {
   default     = []
 }
 
+variable "docker_labels" {
+  type        = "map"
+  description = "The configuration options to send to the `docker_labels`"
+  default     = {}
+}
+
 variable "stop_timeout" {
   description = "Timeout in seconds between sending SIGTERM and SIGKILL to container"
   default     = 30


### PR DESCRIPTION
The goal of the task is to add a { ECS_PROMETHEUS_EXPORTER_PORT: <METRICS_PORT> } docker label to all ECS task definitions that exports Prometheus metrics so we can do an auto-discovery.

Made the same changes from upstream repository: https://github.com/Ebury/terraform-aws-ecs-container-definition/commit/ea97331fd9c5b4e5d5f924bfd07a17a138f13554

I've tested using local code with devel-kafka-rest and it worked.

After merging, I plan to run the pipeline for all terraform VPCs master branch so a new revision can be created with dockerLabels.